### PR TITLE
chore: remove bithound

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 [![build status](https://secure.travis-ci.org/no23reason/jest-trx-results-processor.svg)](http://travis-ci.org/no23reason/jest-trx-results-processor)
 [![npm version](https://img.shields.io/npm/v/jest-trx-results-processor.svg)](https://www.npmjs.com/package/jest-trx-results-processor)
-[![bitHound Score](https://www.bithound.io/github/no23reason/jest-trx-results-processor/badges/score.svg)](https://www.bithound.io/github/no23reason/jest-trx-results-processor)
 [![Dependency Status](https://david-dm.org/no23reason/jest-trx-results-processor.svg)](https://david-dm.org/no23reason/jest-trx-results-processor)
 [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)


### PR DESCRIPTION
BitHound went out of business so we no longer need the references to it