### PR TITLE
finish attribute added to times node on trx generator

### DIFF
--- a/src/trx-generator.ts
+++ b/src/trx-generator.ts
@@ -83,7 +83,8 @@ const renderTimes = (
     .ele("Times")
     .att("creation", startTime)
     .att("queuing", startTime)
-    .att("start", startTime);
+    .att("start", startTime)
+    .att("finish", startTime);
 };
 
 const renderResultSummary = (


### PR DESCRIPTION
sonarqube scanner **cant import the trx file** because the **finish attribute** on Times node is **missing**

sonarqube scanner log:

INFO: Parsing the Visual Studio Test Results file {path}\test-results.trx
WARN: Could not import unit test report '{path}\test-results.trx'

**current**:
\<Times creation="2019-10-01T17:08:53.173Z" queuing="2019-10-01T17:08:53.173Z" start="2019-10-01T17:08:53.173Z"/\>

**expected**:
\<Times creation="2019-10-01T17:08:53.173Z" queuing="2019-10-01T17:08:53.173Z" start="2019-10-01T17:08:53.173Z" finish="2019-10-01T17:08:53.173Z"/\>