### PR TITLE
fix: make options defaulting more robust in reporter

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "trx"
   ],
   "scripts": {
-    "prepublish": "npm run build",
+    "prepublishOnly": "npm run build",
     "build": "tsc",
     "test": "jest --coverage",
     "test:ci": "npm run test:tslint && npm test",
@@ -45,7 +45,7 @@
     "semantic-release": "^15.13.12",
     "ts-jest": "^24.0.2",
     "tslint": "^5.9.1",
-    "typescript": "^3.5.2",
+    "typescript": "^3.7.2",
     "xml2js": "^0.4.19"
   },
   "config": {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,3 +8,6 @@ export const testOutcomeTable: { [outcome: string]: string } = {
   passed: "Passed",
   pending: "NotExecuted",
 };
+
+export const defaultOutputFile = "test-results.trx";
+export const defaultUserName = "anonymous";

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,16 +4,19 @@ import { writeFileSync } from "fs";
 import mkdirp from "mkdirp";
 import path from "path";
 
+import { defaultOutputFile, defaultUserName } from "./constants";
 import { generateTrx, IOptions } from "./trx-generator";
 
 class TrxReporter {
-  constructor(
-    _: Config.GlobalConfig,
-    private options: IOptions = {
-      outputFile: "test-results.trx",
-      defaultUserName: "anonymous",
-    },
-  ) {}
+  private options: IOptions;
+
+  constructor(_: Config.GlobalConfig, options: IOptions) {
+    this.options = {
+      ...options,
+      defaultUserName: options?.defaultUserName ?? defaultUserName,
+      outputFile: options?.outputFile ?? defaultOutputFile,
+    };
+  }
 
   public onRunComplete = (
     _: any,

--- a/src/testResultsProcessor.ts
+++ b/src/testResultsProcessor.ts
@@ -3,12 +3,13 @@ import { writeFileSync } from "fs";
 import mkdirp from "mkdirp";
 import path from "path";
 
+import { defaultOutputFile, defaultUserName } from "./constants";
 import { generateTrx, IOptions } from "./trx-generator";
 
 const processor = (
   options: IOptions = {
-    outputFile: "test-results.trx",
-    defaultUserName: "anonymous",
+    outputFile: defaultOutputFile,
+    defaultUserName,
   },
 ) => (testRunResult: AggregatedResult): AggregatedResult => {
   process.stdout.write("Generating TRX file...");

--- a/yarn.lock
+++ b/yarn.lock
@@ -6111,7 +6111,7 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@^3.5.2:
+typescript@^3.7.2:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.2.tgz#27e489b95fa5909445e9fef5ee48d81697ad18fb"
   integrity sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==


### PR DESCRIPTION
Also the default values were unified in both resultsProcessor and reporter.
TypeScript was upgraded for the elvis and nullish coallescing operators.
Prepublish was changed to prepublishOnly to avoid wasteful compilations.

Fixes #110