### PR TITLE
refactor: replace custom XML input sanitization

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "uuid": "^7.0.0",
-    "xmlbuilder": "^15.0.0"
+    "xmlbuilder": "^15.1.0"
   },
   "devDependencies": {
     "@jest/test-result": "^25.1.0",

--- a/src/trx-generator.ts
+++ b/src/trx-generator.ts
@@ -19,7 +19,6 @@ import {
   getFullTestName,
   getSuitePerTestDuration,
   getTestClassName,
-  sanitizeString,
 } from "./utils";
 
 /**
@@ -204,10 +203,7 @@ const renderTestSuiteResult = (
         result
           .ele("Output")
           .ele("ErrorInfo")
-          .ele(
-            "Message",
-            sanitizeString(testResult.failureMessages.join("\n")),
-          );
+          .ele("Message", testResult.failureMessages.join("\n"));
       }
 
       // Perform any post processing for this test result.
@@ -258,7 +254,7 @@ const renderTestSuiteResult = (
     result
       .ele("Output")
       .ele("ErrorInfo")
-      .ele("Message", sanitizeString(testSuiteResult.failureMessage));
+      .ele("Message", testSuiteResult.failureMessage);
   }
 };
 
@@ -271,6 +267,7 @@ export const generateTrx = (
   );
 
   const resultBuilder = createXmlBuilder("TestRun", {
+    invalidCharReplacement: "",
     version: "1.0",
     encoding: "UTF-8",
   });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -26,10 +26,6 @@ export const formatDuration = (duration: number): string => {
   );
 };
 
-const sanitizationRegex = /[\u0000-\u0008\u000B-\u000C\u000E-\u001F\uD800-\uDFFF\uFFFE-\uFFFF]/g;
-export const sanitizeString = (str: string): string =>
-  str && str.replace(sanitizationRegex, ""); // removes the characters that make xmlbuilder throw
-
 // Auxillary test data functions
 export const getFullTestName = (testResult: AssertionResult): string =>
   testResult.ancestorTitles && testResult.ancestorTitles.length

--- a/yarn.lock
+++ b/yarn.lock
@@ -7470,7 +7470,7 @@ xml2js@^0.4.19:
     sax ">=0.6.0"
     xmlbuilder "~11.0.0"
 
-xmlbuilder@^15.0.0:
+xmlbuilder@^15.1.0:
   version "15.1.0"
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-15.1.0.tgz#4c4c9109180937baeb839978b590250be09a4aef"
   integrity sha512-xae5hmPQnmSFhpiuV3NGXq+FWGOvWy/rIzxVLnRtSSABbPZWltTQCe6WlHDpCq5pGvnGwNsWnS1FdkW7Tx9FNQ==


### PR DESCRIPTION
Replaces custom made XML input sanitization with the one added in xmlbuilder 15.1.0