### PR TITLE
Fixed an issue where todo tests wouldn't be given an outcome as part of the UnitTestResults

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,6 +7,7 @@ export const testOutcomeTable: { [outcome: string]: string } = {
   failed: "Failed",
   passed: "Passed",
   pending: "NotExecuted",
+  todo: "NotExecuted",
 };
 
 export const defaultOutputFile = "test-results.trx";


### PR DESCRIPTION
Looks like there was one spot missed as part of #198 
That change fixed running the tests, but now there's an issue with the trx file, all uses of todo don't get a an outcome tag. Tracked this down to the constants file not having a conversion of todo to "NotExecuted" so I've added that. 

Before this change our pipelines were failing, counting all todo tests as failures. 
I've confirmed with this change that our pipelines succeed, counting the todo tests as others. 