### PR TITLE
Handle test suite failures with passing results

### DIFF
--- a/src/__tests__/trx-generator.test.ts
+++ b/src/__tests__/trx-generator.test.ts
@@ -441,6 +441,110 @@ describe("trx-generator", (): void => {
     });
   });
 
+  it("verify runtime suite failures with passing tests", (done) => {
+    const input: AggregatedResult = {
+      numFailedTestSuites: 1,
+      numFailedTests: 0,
+      numPassedTestSuites: 0,
+      numPassedTests: 1,
+      numPendingTestSuites: 0,
+      numPendingTests: 0,
+      numRuntimeErrorTestSuites: 1,
+      numTodoTests: 0,
+      numTotalTestSuites: 1,
+      numTotalTests: 1,
+      openHandles: [],
+      snapshot: emptySnapshotSummary,
+      startTime: 1511376995239,
+      success: false,
+      testResults: [
+        {
+          failureMessage: "Test suite failed with runtime error",
+          leaks: false,
+          numFailingTests: 0,
+          numPassingTests: 1,
+          numPendingTests: 0,
+          numTodoTests: 0,
+          openHandles: [],
+          perfStats: {
+            end: 1511376996104,
+            start: 1511376995923,
+            runtime: 181,
+            slow: false,
+          },
+          snapshot: emptySnapshot,
+          testFilePath: "C:\\Users\\Github\\test\\test.spec.js",
+          testResults: [
+            {
+              ancestorTitles: [],
+              duration: 0,
+              failureMessages: [],
+              fullName: "first",
+              numPassingAsserts: 0,
+              status: "passed",
+              title: "first",
+              location: {
+                column: 0,
+                line: 0,
+              },
+              failureDetails: [],
+            },
+          ],
+          sourceMaps: {},
+          skipped: false,
+        },
+      ],
+      wasInterrupted: false,
+    };
+
+    const result = generateTrx(input);
+
+    // Verify the summary has the proper test counts.
+    xml2js.parseString(result, (err, parsed) => {
+      expect(err).toBeFalsy();
+      expect(parsed).toBeTruthy();
+      expect(parsed.TestRun).toBeTruthy();
+      expect(parsed.TestRun.$).toBeTruthy();
+      expect(parsed.TestRun.$.xmlns).toEqual(
+        "http://microsoft.com/schemas/VisualStudio/TeamTest/2010",
+      );
+      expect(parsed.TestRun.Results).toBeTruthy();
+      expect(parsed.TestRun.Results.length).toEqual(1);
+      expect(parsed.TestRun.Results[0].UnitTestResult.length).toEqual(2);
+      expect(parsed.TestRun.Results[0].UnitTestResult.length).toEqual(2);
+
+      // Verify the summary values.
+      expect(parsed.TestRun.ResultSummary[0].$.outcome).toBe("Failed");
+      expect(parsed.TestRun.ResultSummary[0].Counters[0].$.total).toBe("2");
+      expect(parsed.TestRun.ResultSummary[0].Counters[0].$.executed).toBe("1");
+      expect(parsed.TestRun.ResultSummary[0].Counters[0].$.passed).toBe("1");
+      expect(parsed.TestRun.ResultSummary[0].Counters[0].$.failed).toBe("0");
+      expect(parsed.TestRun.ResultSummary[0].Counters[0].$.error).toBe("1");
+
+      // First test passed
+      expect(parsed.TestRun.Results[0].UnitTestResult[0].$.outcome).toEqual(
+        "Passed",
+      );
+      expect(parsed.TestRun.Results[0].UnitTestResult[0].$.duration).toEqual(
+        "00:00:00.181",
+      );
+
+      // Second test result represents the failed suite.
+      expect(parsed.TestRun.Results[0].UnitTestResult[1].$.outcome).toEqual(
+        "Failed",
+      );
+      expect(parsed.TestRun.Results[0].UnitTestResult[1].$.duration).toEqual(
+        "0",
+      );
+      expect(
+        parsed.TestRun.Results[0].UnitTestResult[1].Output[0].ErrorInfo[0]
+          .Message[0],
+      ).toEqual("Test suite failed with runtime error");
+
+      done();
+    });
+  });
+
   it("verify postprocess handler", (done) => {
     const input: AggregatedResult = {
       numFailedTestSuites: 0,

--- a/src/__tests__/trx-generator.test.ts
+++ b/src/__tests__/trx-generator.test.ts
@@ -55,7 +55,6 @@ describe("trx-generator", (): void => {
       snapshot: emptySnapshotSummary,
       testResults: [
         {
-          failureMessage: "This did not go as planned",
           coverage: {},
           leaks: false,
           numFailingTests: 1,
@@ -151,7 +150,6 @@ describe("trx-generator", (): void => {
       snapshot: emptySnapshotSummary,
       testResults: [
         {
-          failureMessage: "This did not go as planned\uDFFF",
           coverage: {},
           leaks: false,
           numFailingTests: 1,

--- a/src/__tests__/trx-generator.test.ts
+++ b/src/__tests__/trx-generator.test.ts
@@ -388,6 +388,10 @@ describe("trx-generator", (): void => {
           testResults: [],
           sourceMaps: {},
           skipped: false,
+          testExecError: {
+            message: '',
+            stack: 'Failing stack',
+          }
         },
       ],
       wasInterrupted: false,
@@ -435,7 +439,7 @@ describe("trx-generator", (): void => {
       expect(
         parsed.TestRun.Results[0].UnitTestResult[1].Output[0].ErrorInfo[0]
           .Message[0],
-      ).toEqual("Test suite failed with runtime error");
+      ).toEqual("Failing stack");
 
       done();
     });
@@ -492,6 +496,10 @@ describe("trx-generator", (): void => {
           ],
           sourceMaps: {},
           skipped: false,
+          testExecError: {
+            message: '',
+            stack: 'Failing stack',
+          }
         },
       ],
       wasInterrupted: false,
@@ -539,7 +547,7 @@ describe("trx-generator", (): void => {
       expect(
         parsed.TestRun.Results[0].UnitTestResult[1].Output[0].ErrorInfo[0]
           .Message[0],
-      ).toEqual("Test suite failed with runtime error");
+      ).toEqual("Failing stack");
 
       done();
     });

--- a/src/__tests__/trx-generator.test.ts
+++ b/src/__tests__/trx-generator.test.ts
@@ -55,6 +55,7 @@ describe("trx-generator", (): void => {
       snapshot: emptySnapshotSummary,
       testResults: [
         {
+          failureMessage: "This did not go as planned",
           coverage: {},
           leaks: false,
           numFailingTests: 1,
@@ -150,6 +151,7 @@ describe("trx-generator", (): void => {
       snapshot: emptySnapshotSummary,
       testResults: [
         {
+          failureMessage: "This did not go as planned\uDFFF",
           coverage: {},
           leaks: false,
           numFailingTests: 1,

--- a/src/trx-generator.ts
+++ b/src/trx-generator.ts
@@ -218,7 +218,7 @@ const renderTestSuiteResult = (
     });
   }
 
-  if (testSuiteResult.failureMessage) {
+  if (testSuiteResult.testExecError?.stack) {
     // For suites that failed to run, we will generate a test result that documents the failure.
     // This occurs when there is a failure compiling/loading the suite or an assertion in a before/after hook fails,
     // not when a test in the suite fails.
@@ -262,7 +262,7 @@ const renderTestSuiteResult = (
     result
       .ele("Output")
       .ele("ErrorInfo")
-      .ele("Message", testSuiteResult.failureMessage);
+      .ele("Message", testSuiteResult.testExecError.stack);
   }
 };
 

--- a/src/trx-generator.ts
+++ b/src/trx-generator.ts
@@ -216,7 +216,9 @@ const renderTestSuiteResult = (
         );
       }
     });
-  } else if (testSuiteResult.failureMessage) {
+  }
+
+  if (testSuiteResult.failureMessage) {
     // For suites that failed to run, we will generate a test result that documents the failure.
     // This occurs when there is a failure compiling/loading the suite, not when a test in the suite fails.
     const testId = uuidv4();

--- a/src/trx-generator.ts
+++ b/src/trx-generator.ts
@@ -220,7 +220,8 @@ const renderTestSuiteResult = (
 
   if (testSuiteResult.failureMessage) {
     // For suites that failed to run, we will generate a test result that documents the failure.
-    // This occurs when there is a failure compiling/loading the suite or an assertion in a before/after hook fails, not when a test in the suite fails.
+    // This occurs when there is a failure compiling/loading the suite or an assertion in a before/after hook fails,
+    // not when a test in the suite fails.
     const testId = uuidv4();
     const executionId = uuidv4();
     const fullTestName = path.basename(testSuiteResult.testFilePath);

--- a/src/trx-generator.ts
+++ b/src/trx-generator.ts
@@ -220,7 +220,7 @@ const renderTestSuiteResult = (
 
   if (testSuiteResult.failureMessage) {
     // For suites that failed to run, we will generate a test result that documents the failure.
-    // This occurs when there is a failure compiling/loading the suite, not when a test in the suite fails.
+    // This occurs when there is a failure compiling/loading the suite or an assertion in a before/after hook fails, not when a test in the suite fails.
     const testId = uuidv4();
     const executionId = uuidv4();
     const fullTestName = path.basename(testSuiteResult.testFilePath);


### PR DESCRIPTION
Test suites can be marked as failures even if tests pass.  The main example I see of this is an assertion in an `afterEach` or `afterAll` hook.  This change allows the synthetic failure to be added alongside passing tests