### PR TITLE
fix: use duration field of AssertionResult to report test duration

### DIFF
--- a/src/__tests__/trx-generator.test.ts
+++ b/src/__tests__/trx-generator.test.ts
@@ -84,6 +84,7 @@ describe("trx-generator", (): void => {
                 line: 0,
               },
               failureDetails: [],
+              duration: 4100,
             },
             {
               ancestorTitles: ["foo's", "bar method"],
@@ -97,6 +98,7 @@ describe("trx-generator", (): void => {
                 line: 0,
               },
               failureDetails: [],
+              duration: 2900,
             },
           ],
         },
@@ -119,13 +121,13 @@ describe("trx-generator", (): void => {
         "Passed",
       );
       expect(parsed.TestRun.Results[0].UnitTestResult[0].$.duration).toEqual(
-        "00:00:03.500",
+        "00:00:04.100",
       );
       expect(parsed.TestRun.Results[0].UnitTestResult[1].$.outcome).toEqual(
         "Failed",
       );
       expect(parsed.TestRun.Results[0].UnitTestResult[1].$.duration).toEqual(
-        "00:00:03.500",
+        "00:00:02.900",
       );
 
       done();
@@ -179,6 +181,7 @@ describe("trx-generator", (): void => {
                 line: 0,
               },
               failureDetails: [],
+              duration: 4100,
             },
             {
               ancestorTitles: ["foo's", "bar method"],
@@ -192,6 +195,7 @@ describe("trx-generator", (): void => {
                 line: 0,
               },
               failureDetails: [],
+              duration: 2900,
             },
           ],
         },
@@ -237,7 +241,7 @@ describe("trx-generator", (): void => {
           testResults: [
             {
               ancestorTitles: [],
-              duration: 0,
+              duration: 181,
               failureMessages: [],
               fullName: "first",
               numPassingAsserts: 0,
@@ -295,7 +299,7 @@ describe("trx-generator", (): void => {
           testResults: [
             {
               ancestorTitles: [],
-              duration: 0,
+              duration: 181,
               failureMessages: [],
               fullName: "first",
               numPassingAsserts: 0,
@@ -353,7 +357,7 @@ describe("trx-generator", (): void => {
           testResults: [
             {
               ancestorTitles: [],
-              duration: 0,
+              duration: 181,
               failureMessages: [],
               fullName: "first",
               numPassingAsserts: 0,
@@ -481,7 +485,7 @@ describe("trx-generator", (): void => {
           testResults: [
             {
               ancestorTitles: [],
-              duration: 0,
+              duration: 181,
               failureMessages: [],
               fullName: "first",
               numPassingAsserts: 0,
@@ -588,7 +592,7 @@ describe("trx-generator", (): void => {
           testResults: [
             {
               ancestorTitles: [],
-              duration: 0,
+              duration: 181,
               failureMessages: [],
               fullName: "first",
               numPassingAsserts: 0,

--- a/src/trx-generator.ts
+++ b/src/trx-generator.ts
@@ -17,7 +17,6 @@ import {
   formatDuration,
   getEnvInfo,
   getFullTestName,
-  getSuitePerTestDuration,
   getTestClassName,
 } from "./utils";
 
@@ -148,15 +147,14 @@ const renderTestSuiteResult = (
     ) => void,
   ],
 ): void => {
-  const perTestDuration = getSuitePerTestDuration(testSuiteResult);
-  const perTestDurationFormatted = formatDuration(perTestDuration);
-
   if (testSuiteResult.testResults && testSuiteResult.testResults.length) {
-    testSuiteResult.testResults.forEach((testResult, index) => {
+    let runningDuration = 0;
+    testSuiteResult.testResults.forEach((testResult) => {
       const testId = uuidv4();
       const executionId = uuidv4();
       const fullTestName = getFullTestName(testResult);
       const filepath = path.relative("./", testSuiteResult.testFilePath);
+      const duration = testResult.duration || 0;
 
       // UnitTest
       const unitTest = testDefinitionsNode
@@ -185,22 +183,24 @@ const renderTestSuiteResult = (
         .att("executionId", executionId)
         .att("testName", fullTestName)
         .att("computerName", computerName)
-        .att("duration", perTestDurationFormatted)
+        .att("duration", formatDuration(duration))
         .att(
           "startTime",
           new Date(
-            testSuiteResult.perfStats.start + index * perTestDuration,
+            testSuiteResult.perfStats.start + runningDuration,
           ).toISOString(),
         )
         .att(
           "endTime",
           new Date(
-            testSuiteResult.perfStats.start + (index + 1) * perTestDuration,
+            testSuiteResult.perfStats.start + runningDuration,
           ).toISOString(),
         )
         .att("testType", testType)
         .att("outcome", testOutcomeTable[testResult.status])
         .att("testListId", testListNotInListId);
+
+      runningDuration += duration;
 
       if (testResult.status === "failed") {
         result

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { AssertionResult, TestResult } from "@jest/test-result";
+import { AssertionResult } from "@jest/test-result";
 import * as os from "os";
 
 // Adapted from https://github.com/hatchteam/karma-trx-reporter
@@ -33,17 +33,6 @@ export const getTestClassName = (testResult: AssertionResult): string =>
   testResult.ancestorTitles && testResult.ancestorTitles.length
     ? testResult.ancestorTitles[0]
     : "No suite";
-
-export const getSuitePerTestDuration = (testSuiteResult: TestResult): number =>
-  // take the total duration of suite and divide it by the number of tests
-  // (Jest does not provide per test performance info)
-  Math.floor(
-    (testSuiteResult.perfStats.end - testSuiteResult.perfStats.start) /
-      (testSuiteResult.numPassingTests +
-        testSuiteResult.numFailingTests +
-        testSuiteResult.numPendingTests +
-        testSuiteResult.numTodoTests),
-  );
 
 export const getEnvInfo = (
   defaultUserName = "anonymous",


### PR DESCRIPTION
Some archaeology shows that it's been there since at least facebook/jest@dc355000db, from 24.2.0 (or earlier).

I hope we can chance breaking compatibility for people using pre-2019 versions of jest...

Fixes #516