### PR TITLE
fix: correct logic for startTime in trx-generator.ts

### DIFF
--- a/src/trx-generator.ts
+++ b/src/trx-generator.ts
@@ -187,7 +187,7 @@ const renderTestSuiteResult = (
         .att(
           "startTime",
           new Date(
-            testSuiteResult.perfStats.start + runningDuration,
+            testSuiteResult.perfStats.start,
           ).toISOString(),
         )
         .att(


### PR DESCRIPTION
fix startTime